### PR TITLE
Add padding to bottom of container so that viz clears footer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@ a, a:visited, a:focus {
 }
 
 .container {
-  padding: 0 10px;
+  padding: 0 10px 80px;
 }
 
 .title {


### PR DESCRIPTION
The fixed footer cut off the bottom row: this fixes it

Before to left, After to right:

![image](https://cloud.githubusercontent.com/assets/442115/7396463/1b897c72-ee6f-11e4-80ca-a45bd1c878be.png) ![image](https://cloud.githubusercontent.com/assets/442115/7396450/04292bb8-ee6f-11e4-818c-d9f97766a4da.png)
